### PR TITLE
Support edge-to-edge display

### DIFF
--- a/app/src/main/java/eu/zimbelstern/tournant/ui/MainActivity.kt
+++ b/app/src/main/java/eu/zimbelstern/tournant/ui/MainActivity.kt
@@ -7,6 +7,7 @@ import android.content.Intent
 import android.content.SharedPreferences.OnSharedPreferenceChangeListener
 import android.graphics.Typeface
 import android.net.Uri
+import android.os.Build
 import android.os.Bundle
 import android.text.Spanned
 import android.text.style.StyleSpan
@@ -29,7 +30,10 @@ import androidx.core.net.toUri
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import androidx.core.text.toSpannable
 import androidx.core.view.GravityCompat
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.children
+import androidx.core.view.updatePadding
 import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.ConcatAdapter
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
@@ -350,6 +354,16 @@ class MainActivity : AppCompatActivity(), RecipeListAdapter.RecipeListInterface 
 			binding.navDrawerButton.setOnClickListener {
 				binding.root.openDrawer(GravityCompat.START)
 			}
+		}
+
+		// Handle enforced edge-to-edge display on Android 15
+		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+			binding.root.setStatusBarBackgroundColor(getColor(R.color.bar_color))
+		}
+		ViewCompat.setOnApplyWindowInsetsListener(binding.navDrawer.root) { view, insets ->
+			val bars = insets.getInsets(WindowInsetsCompat.Type.navigationBars())
+			view.updatePadding(bottom = bars.bottom)
+			WindowInsetsCompat.CONSUMED
 		}
 	}
 

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -3,11 +3,14 @@
 	xmlns:app="http://schemas.android.com/apk/res-auto"
 	xmlns:tools="http://schemas.android.com/tools"
 	android:layout_width="match_parent"
-	android:layout_height="match_parent">
+	android:layout_height="match_parent"
+	android:background="@color/bar_color"
+	android:fitsSystemWindows="true">
 
 	<LinearLayout
 		android:layout_width="match_parent"
 		android:layout_height="match_parent"
+		android:background="@drawable/background_repeat"
 		android:orientation="vertical">
 
 		<androidx.appcompat.widget.Toolbar

--- a/app/src/main/res/layout/activity_recipe.xml
+++ b/app/src/main/res/layout/activity_recipe.xml
@@ -13,11 +13,15 @@
 		android:id="@+id/recipe_detail_root"
 		android:layout_width="match_parent"
 		android:layout_height="match_parent"
+		android:background="@color/bar_color"
+		android:fillViewport="true"
+		android:fitsSystemWindows="true"
 		tools:context=".ui.RecipeActivity">
 
 		<LinearLayout
 			android:layout_width="match_parent"
-			android:layout_height="wrap_content"
+			android:layout_height="match_parent"
+			android:background="@drawable/background_repeat"
 			android:orientation="vertical">
 
 			<com.google.android.flexbox.FlexboxLayout
@@ -488,7 +492,7 @@
 						android:layout_width="match_parent"
 						android:layout_height="wrap_content"
 						android:lineSpacingExtra="4sp"
-						android:textSize="@dimen/font_size_text"/>
+						android:textSize="@dimen/font_size_text" />
 
 				</LinearLayout>
 

--- a/app/src/main/res/layout/activity_recipe_editing.xml
+++ b/app/src/main/res/layout/activity_recipe_editing.xml
@@ -10,509 +10,520 @@
 
 	<androidx.core.widget.NestedScrollView
 		android:layout_width="match_parent"
-		android:layout_height="match_parent">
+		android:layout_height="match_parent"
+		android:background="@color/bar_color"
+		android:fillViewport="true"
+		android:fitsSystemWindows="true">
 
-		<com.google.android.material.card.MaterialCardView
+		<FrameLayout
 			android:layout_width="match_parent"
 			android:layout_height="match_parent"
-			android:layout_margin="16dp"
-			android:clipToPadding="false"
-			android:elevation="4dp"
-			app:cardCornerRadius="8dp">
+			android:background="@drawable/background_repeat">
 
-			<LinearLayout
+			<com.google.android.material.card.MaterialCardView
 				android:layout_width="match_parent"
-				android:layout_height="wrap_content"
-				android:orientation="vertical"
-				android:divider="@drawable/divider_vertical"
-				android:showDividers="middle"
-				android:paddingVertical="16dp"
-				android:clipChildren="false">
+				android:layout_height="match_parent"
+				android:layout_margin="16dp"
+				android:background="@drawable/background_repeat"
+				android:clipToPadding="false"
+				android:elevation="4dp"
+				app:cardCornerRadius="8dp">
 
-				<com.google.android.flexbox.FlexboxLayout
+				<LinearLayout
 					android:layout_width="match_parent"
 					android:layout_height="wrap_content"
-					android:paddingStart="16dp"
-					android:paddingBottom="8dp"
-					app:flexWrap="wrap"
-					app:flexDirection="row_reverse"
-					tools:ignore="RtlSymmetry">
+					android:clipChildren="false"
+					android:divider="@drawable/divider_vertical"
+					android:orientation="vertical"
+					android:paddingVertical="16dp"
+					android:showDividers="middle">
 
-					<androidx.constraintlayout.widget.ConstraintLayout
-						android:layout_width="300dp"
-						android:layout_height="wrap_content"
-						app:layout_flexGrow="1"
-						android:layout_marginEnd="16dp">
-
-					<ImageView
-						android:id="@+id/edit_image"
+					<com.google.android.flexbox.FlexboxLayout
 						android:layout_width="match_parent"
-						android:layout_height="0dp"
-						android:importantForAccessibility="no"
-						app:layout_constraintTop_toTopOf="parent"
-						app:layout_constraintBottom_toBottomOf="parent"
-						app:layout_constraintDimensionRatio="1:1"/>
-
-						<LinearLayout
-							android:layout_width="wrap_content"
-							android:layout_height="wrap_content"
-							android:orientation="horizontal"
-							app:layout_constraintTop_toTopOf="parent"
-							app:layout_constraintBottom_toBottomOf="parent"
-							app:layout_constraintLeft_toLeftOf="parent"
-							app:layout_constraintRight_toRightOf="parent">
-
-							<ImageButton
-								android:id="@+id/edit_image_add"
-								android:layout_width="72dp"
-								android:layout_height="72dp"
-								android:layout_margin="8dp"
-								android:background="@drawable/button_round"
-								android:src="@drawable/ic_photo_add"
-								android:scaleType="centerCrop"
-								android:padding="16dp"
-								android:contentDescription="@string/add_photo"/>
-
-							<ImageButton
-								android:id="@+id/edit_image_remove"
-								android:layout_width="72dp"
-								android:layout_height="72dp"
-								android:layout_margin="8dp"
-								android:background="@drawable/button_round"
-								android:src="@drawable/ic_clear"
-								android:scaleType="centerCrop"
-								android:padding="16dp"
-								android:contentDescription="@string/remove_photo"
-								android:visibility="gone"
-								tools:visibility="visible"/>
-
-						</LinearLayout>
-
-					</androidx.constraintlayout.widget.ConstraintLayout>
-
-					<LinearLayout
-						android:layout_width="300dp"
 						android:layout_height="wrap_content"
-						app:layout_flexGrow="1"
-						android:layout_marginTop="8dp"
-						android:layout_marginEnd="16dp"
-						android:orientation="vertical">
-
-						<com.google.android.material.textfield.TextInputLayout
-							android:layout_width="match_parent"
-							android:layout_height="wrap_content"
-							app:hintAnimationEnabled="false"
-							style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox">
-
-							<com.google.android.material.textfield.TextInputEditText
-								android:id="@+id/edit_title"
-								android:layout_width="match_parent"
-								android:layout_height="wrap_content"
-								android:imeOptions="actionNext"
-								android:inputType="text"
-								android:hint="@string/title"
-								android:text="@={recipe.title}"/>
-
-						</com.google.android.material.textfield.TextInputLayout>
-
-						<com.google.android.material.textfield.TextInputLayout
-							android:layout_width="match_parent"
-							android:layout_height="wrap_content"
-							app:hintAnimationEnabled="false"
-							style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox">
-
-							<com.google.android.material.textfield.TextInputEditText
-								android:id="@+id/edit_description"
-								android:layout_width="match_parent"
-								android:layout_height="wrap_content"
-								android:imeOptions="actionNext"
-								android:inputType="text"
-								android:hint="@string/description"
-								android:text="@={recipe.description}"/>
-
-						</com.google.android.material.textfield.TextInputLayout>
-
-						<TextView
-							android:layout_width="match_parent"
-							android:layout_height="wrap_content"
-							android:layout_marginTop="8dp"
-							android:paddingStart="2sp"
-							android:text="@string/rating"/>
-
-						<LinearLayout
-							android:layout_width="match_parent"
-							android:layout_height="wrap_content"
-							android:orientation="horizontal"
-							android:divider="@drawable/divider_horizontal"
-							android:showDividers="middle">
-
-							<RatingBar
-								android:id="@+id/edit_rating"
-								android:layout_width="wrap_content"
-								android:layout_height="wrap_content"
-								android:rating="@={recipe.rating}"/>
-
-							<ImageButton
-								android:id="@+id/unset_rating"
-								android:layout_width="wrap_content"
-								android:layout_height="match_parent"
-								android:layout_marginBottom="4dp"
-								android:src="@drawable/ic_clear"
-								android:contentDescription="@string/unset_rating"/>
-
-						</LinearLayout>
-
-						<LinearLayout
-							android:layout_width="match_parent"
-							android:layout_height="wrap_content"
-							android:orientation="horizontal"
-							android:layout_marginTop="8dp"
-							android:divider="@drawable/divider_horizontal"
-							android:showDividers="middle"
-							android:baselineAligned="false">
-
-							<com.google.android.material.textfield.TextInputLayout
-								android:layout_width="0dp"
-								android:layout_height="wrap_content"
-								android:layout_weight="1"
-								app:endIconMode="none"
-								app:hintAnimationEnabled="false"
-								style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox.ExposedDropdownMenu">
-
-								<com.google.android.material.textfield.MaterialAutoCompleteTextView
-									android:id="@+id/edit_category"
-									android:layout_width="match_parent"
-									android:layout_height="wrap_content"
-									android:imeOptions="actionNext"
-									android:inputType="text"
-									android:hint="@string/category"
-									android:text="@={recipe.category}"/>
-
-							</com.google.android.material.textfield.TextInputLayout>
-
-							<com.google.android.material.textfield.TextInputLayout
-								android:layout_width="0dp"
-								android:layout_height="wrap_content"
-								android:layout_weight="1"
-								app:endIconMode="none"
-								app:hintAnimationEnabled="false"
-								style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox.ExposedDropdownMenu">
-
-								<com.google.android.material.textfield.MaterialAutoCompleteTextView
-									android:id="@+id/edit_cuisine"
-									android:layout_width="match_parent"
-									android:layout_height="wrap_content"
-									android:imeOptions="actionNext"
-									android:inputType="text"
-									android:hint="@string/cuisine"
-									android:text="@={recipe.cuisine}"/>
-
-							</com.google.android.material.textfield.TextInputLayout>
-
-						</LinearLayout>
-
-						<com.google.android.material.textfield.TextInputLayout
-							android:layout_width="match_parent"
-							android:layout_height="wrap_content"
-							app:endIconMode="none"
-							app:hintAnimationEnabled="false"
-							style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox.ExposedDropdownMenu">
-
-							<com.google.android.material.textfield.MaterialAutoCompleteTextView
-								android:id="@+id/edit_source"
-								android:layout_width="match_parent"
-								android:layout_height="wrap_content"
-								android:imeOptions="actionNext"
-								android:inputType="text"
-								android:hint="@string/source"
-								android:text="@={recipe.source}"/>
-
-						</com.google.android.material.textfield.TextInputLayout>
-
-						<com.google.android.material.textfield.TextInputLayout
-							android:layout_width="match_parent"
-							android:layout_height="wrap_content"
-							app:hintAnimationEnabled="false"
-							style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox">
-
-							<com.google.android.material.textfield.TextInputEditText
-								android:id="@+id/edit_link"
-								android:layout_width="match_parent"
-								android:layout_height="wrap_content"
-								android:imeOptions="actionNext"
-								android:inputType="text"
-								android:hint="@string/webpage"
-								android:text="@={recipe.link}"/>
-
-						</com.google.android.material.textfield.TextInputLayout>
-
-						<LinearLayout
-							android:layout_width="match_parent"
-							android:layout_height="wrap_content"
-							android:orientation="horizontal"
-							android:layout_marginTop="16dp">
-
-							<TextView
-								android:layout_width="0dp"
-								android:layout_height="wrap_content"
-								android:layout_weight="1"
-								android:text="@string/preptime"/>
-
-							<TextView
-								android:layout_width="0dp"
-								android:layout_height="wrap_content"
-								android:layout_weight="1"
-								android:text="@string/cooktime"/>
-
-						</LinearLayout>
-
-						<LinearLayout
-							android:layout_width="match_parent"
-							android:layout_height="wrap_content"
-							android:orientation="horizontal"
-							android:divider="@drawable/divider_horizontal"
-							android:showDividers="middle"
-							android:baselineAligned="false">
-
-							<com.google.android.material.textfield.TextInputLayout
-								android:layout_width="0dp"
-								android:layout_height="wrap_content"
-								android:layout_weight="0.2"
-								app:suffixText="h"
-								app:expandedHintEnabled="false"
-								style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox">
-
-								<com.google.android.material.textfield.TextInputEditText
-									android:id="@+id/edit_preptime_h"
-									android:layout_width="match_parent"
-									android:layout_height="wrap_content"
-									android:imeOptions="actionNext"
-									android:inputType="number"
-									android:text="@={Converter.timeToHour(recipe.preptime, recipe.preptime)}"/>
-
-							</com.google.android.material.textfield.TextInputLayout>
-
-							<com.google.android.material.textfield.TextInputLayout
-								android:layout_width="0dp"
-								android:layout_height="wrap_content"
-								android:layout_weight="0.3"
-								app:suffixText="min"
-								app:expandedHintEnabled="false"
-								style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox">
-
-								<com.google.android.material.textfield.TextInputEditText
-									android:id="@+id/edit_preptime_min"
-									android:layout_width="match_parent"
-									android:layout_height="wrap_content"
-									android:imeOptions="actionNext"
-									android:inputType="number"
-									android:text="@={Converter.timeToMin(recipe.preptime, recipe.preptime)}"/>
-
-							</com.google.android.material.textfield.TextInputLayout>
-
-							<com.google.android.material.textfield.TextInputLayout
-								android:layout_width="0dp"
-								android:layout_height="wrap_content"
-								android:layout_weight="0.2"
-								app:suffixText="h"
-								app:expandedHintEnabled="false"
-								style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox">
-
-								<com.google.android.material.textfield.TextInputEditText
-									android:id="@+id/edit_cooktime_h"
-									android:layout_width="match_parent"
-									android:layout_height="wrap_content"
-									android:imeOptions="actionNext"
-									android:inputType="number"
-									android:text="@={Converter.timeToHour(recipe.cooktime, recipe.cooktime)}"/>
-
-							</com.google.android.material.textfield.TextInputLayout>
-
-							<com.google.android.material.textfield.TextInputLayout
-								android:layout_width="0dp"
-								android:layout_height="wrap_content"
-								android:layout_weight="0.3"
-								app:suffixText="min"
-								app:expandedHintEnabled="false"
-								style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox">
-
-								<com.google.android.material.textfield.TextInputEditText
-									android:id="@+id/edit_cooktime_min"
-									android:layout_width="match_parent"
-									android:layout_height="wrap_content"
-									android:imeOptions="actionNext"
-									android:inputType="number"
-									android:text="@={Converter.timeToMin(recipe.cooktime, recipe.cooktime)}"/>
-
-							</com.google.android.material.textfield.TextInputLayout>
-
-						</LinearLayout>
-
-					</LinearLayout>
-
-				</com.google.android.flexbox.FlexboxLayout>
-
-				<com.google.android.flexbox.FlexboxLayout
-					android:layout_width="match_parent"
-					android:layout_height="wrap_content"
-					android:paddingStart="16dp"
-					app:flexWrap="wrap"
-					tools:ignore="RtlSymmetry">
-
-					<LinearLayout
-						android:layout_width="300dp"
-						android:layout_height="wrap_content"
-						app:layout_flexGrow="1"
-						android:layout_marginEnd="16dp"
-						android:orientation="vertical"
-						android:divider="@drawable/divider_vertical"
-						android:showDividers="middle"
-						android:clipChildren="false">
-
-						<TextView
-							android:layout_width="match_parent"
-							android:layout_height="wrap_content"
-							android:text="@string/ingredients"/>
-
-						<LinearLayout
-							android:layout_width="match_parent"
-							android:layout_height="wrap_content"
-							android:orientation="horizontal"
-							android:divider="@drawable/divider_horizontal"
-							android:showDividers="middle"
-							android:baselineAligned="false">
-
-							<com.google.android.material.textfield.TextInputLayout
-								android:layout_width="0dp"
-								android:layout_height="wrap_content"
-								android:layout_weight="0.3"
-								style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox">
-
-								<com.google.android.material.textfield.TextInputEditText
-									android:id="@+id/edit_yield_value"
-									android:layout_width="match_parent"
-									android:layout_height="wrap_content"
-									android:imeOptions="actionNext"
-									android:inputType="numberDecimal"
-									android:hint="@string/yield"
-									android:text="@={Converter.doubleToString(recipe.yieldValue, recipe.yieldValue)}"/>
-
-							</com.google.android.material.textfield.TextInputLayout>
-
-
-							<com.google.android.material.textfield.TextInputLayout
-								android:layout_width="0dp"
-								android:layout_height="wrap_content"
-								android:layout_weight="0.7"
-								app:endIconMode="none"
-								style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox.ExposedDropdownMenu">
-
-								<com.google.android.material.textfield.MaterialAutoCompleteTextView
-									android:id="@+id/edit_yield_unit"
-									android:layout_width="match_parent"
-									android:layout_height="wrap_content"
-									android:imeOptions="actionNext"
-									android:inputType="text"
-									android:text="@={recipe.yieldUnit}"/>
-
-							</com.google.android.material.textfield.TextInputLayout>
-
-						</LinearLayout>
-
-						<androidx.recyclerview.widget.RecyclerView
-							android:id="@+id/edit_ingredients"
-							android:layout_width="match_parent"
-							android:layout_height="wrap_content"
-							android:layout_marginHorizontal="-8dp"
-							app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"/>
+						android:paddingStart="16dp"
+						android:paddingBottom="8dp"
+						app:flexDirection="row_reverse"
+						app:flexWrap="wrap"
+						tools:ignore="RtlSymmetry">
 
 						<androidx.constraintlayout.widget.ConstraintLayout
-							android:layout_width="match_parent"
+							android:layout_width="300dp"
 							android:layout_height="wrap_content"
-							android:orientation="vertical">
+							android:layout_marginEnd="16dp"
+							app:layout_flexGrow="1">
 
-							<com.google.android.material.button.MaterialButton
-								android:id="@+id/edit_ingredients_new_ingredient"
-								android:layout_width="wrap_content"
-								android:layout_height="wrap_content"
-								android:text="@string/ingredient"
-								app:icon="@drawable/ic_add_circle"
-								tools:ignore="MissingConstraints"/>
-
-							<com.google.android.material.button.MaterialButton
-								android:id="@+id/edit_ingredients_new_reference"
-								android:layout_width="wrap_content"
-								android:layout_height="wrap_content"
-								android:text="@string/recipe"
-								app:icon="@drawable/ic_link_new"
-								tools:ignore="MissingConstraints"/>
-
-							<com.google.android.material.button.MaterialButton
-								android:id="@+id/edit_ingredients_new_group"
-								android:layout_width="wrap_content"
-								android:layout_height="wrap_content"
-								android:text="@string/group"
-								app:icon="@drawable/ic_group"
-								tools:ignore="MissingConstraints"/>
-
-							<androidx.constraintlayout.helper.widget.Flow
+							<ImageView
+								android:id="@+id/edit_image"
 								android:layout_width="match_parent"
+								android:layout_height="0dp"
+								android:importantForAccessibility="no"
+								app:layout_constraintBottom_toBottomOf="parent"
+								app:layout_constraintDimensionRatio="1:1"
+								app:layout_constraintTop_toTopOf="parent" />
+
+							<LinearLayout
+								android:layout_width="wrap_content"
 								android:layout_height="wrap_content"
-								app:layout_constraintTop_toTopOf="parent"
-								app:constraint_referenced_ids="edit_ingredients_new_ingredient, edit_ingredients_new_reference, edit_ingredients_new_group"
-								app:flow_horizontalBias="0.5"
-								app:flow_horizontalGap="8dp"
-								app:flow_horizontalStyle="packed"
-								app:flow_wrapMode="chain"/>
+								android:orientation="horizontal"
+								app:layout_constraintBottom_toBottomOf="parent"
+								app:layout_constraintLeft_toLeftOf="parent"
+								app:layout_constraintRight_toRightOf="parent"
+								app:layout_constraintTop_toTopOf="parent">
+
+								<ImageButton
+									android:id="@+id/edit_image_add"
+									android:layout_width="72dp"
+									android:layout_height="72dp"
+									android:layout_margin="8dp"
+									android:background="@drawable/button_round"
+									android:contentDescription="@string/add_photo"
+									android:padding="16dp"
+									android:scaleType="centerCrop"
+									android:src="@drawable/ic_photo_add" />
+
+								<ImageButton
+									android:id="@+id/edit_image_remove"
+									android:layout_width="72dp"
+									android:layout_height="72dp"
+									android:layout_margin="8dp"
+									android:background="@drawable/button_round"
+									android:contentDescription="@string/remove_photo"
+									android:padding="16dp"
+									android:scaleType="centerCrop"
+									android:src="@drawable/ic_clear"
+									android:visibility="gone"
+									tools:visibility="visible" />
+
+							</LinearLayout>
 
 						</androidx.constraintlayout.widget.ConstraintLayout>
 
-					</LinearLayout>
+						<LinearLayout
+							android:layout_width="300dp"
+							android:layout_height="wrap_content"
+							android:layout_marginTop="8dp"
+							android:layout_marginEnd="16dp"
+							android:orientation="vertical"
+							app:layout_flexGrow="1">
+
+							<com.google.android.material.textfield.TextInputLayout
+								style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"
+								android:layout_width="match_parent"
+								android:layout_height="wrap_content"
+								app:hintAnimationEnabled="false">
+
+								<com.google.android.material.textfield.TextInputEditText
+									android:id="@+id/edit_title"
+									android:layout_width="match_parent"
+									android:layout_height="wrap_content"
+									android:hint="@string/title"
+									android:imeOptions="actionNext"
+									android:inputType="text"
+									android:text="@={recipe.title}" />
+
+							</com.google.android.material.textfield.TextInputLayout>
+
+							<com.google.android.material.textfield.TextInputLayout
+								style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"
+								android:layout_width="match_parent"
+								android:layout_height="wrap_content"
+								app:hintAnimationEnabled="false">
+
+								<com.google.android.material.textfield.TextInputEditText
+									android:id="@+id/edit_description"
+									android:layout_width="match_parent"
+									android:layout_height="wrap_content"
+									android:hint="@string/description"
+									android:imeOptions="actionNext"
+									android:inputType="text"
+									android:text="@={recipe.description}" />
+
+							</com.google.android.material.textfield.TextInputLayout>
+
+							<TextView
+								android:layout_width="match_parent"
+								android:layout_height="wrap_content"
+								android:layout_marginTop="8dp"
+								android:paddingStart="2sp"
+								android:text="@string/rating" />
+
+							<LinearLayout
+								android:layout_width="match_parent"
+								android:layout_height="wrap_content"
+								android:divider="@drawable/divider_horizontal"
+								android:orientation="horizontal"
+								android:showDividers="middle">
+
+								<RatingBar
+									android:id="@+id/edit_rating"
+									android:layout_width="wrap_content"
+									android:layout_height="wrap_content"
+									android:rating="@={recipe.rating}" />
+
+								<ImageButton
+									android:id="@+id/unset_rating"
+									android:layout_width="wrap_content"
+									android:layout_height="match_parent"
+									android:layout_marginBottom="4dp"
+									android:contentDescription="@string/unset_rating"
+									android:src="@drawable/ic_clear" />
+
+							</LinearLayout>
+
+							<LinearLayout
+								android:layout_width="match_parent"
+								android:layout_height="wrap_content"
+								android:layout_marginTop="8dp"
+								android:baselineAligned="false"
+								android:divider="@drawable/divider_horizontal"
+								android:orientation="horizontal"
+								android:showDividers="middle">
+
+								<com.google.android.material.textfield.TextInputLayout
+									style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox.ExposedDropdownMenu"
+									android:layout_width="0dp"
+									android:layout_height="wrap_content"
+									android:layout_weight="1"
+									app:endIconMode="none"
+									app:hintAnimationEnabled="false">
+
+									<com.google.android.material.textfield.MaterialAutoCompleteTextView
+										android:id="@+id/edit_category"
+										android:layout_width="match_parent"
+										android:layout_height="wrap_content"
+										android:hint="@string/category"
+										android:imeOptions="actionNext"
+										android:inputType="text"
+										android:text="@={recipe.category}" />
+
+								</com.google.android.material.textfield.TextInputLayout>
+
+								<com.google.android.material.textfield.TextInputLayout
+									style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox.ExposedDropdownMenu"
+									android:layout_width="0dp"
+									android:layout_height="wrap_content"
+									android:layout_weight="1"
+									app:endIconMode="none"
+									app:hintAnimationEnabled="false">
+
+									<com.google.android.material.textfield.MaterialAutoCompleteTextView
+										android:id="@+id/edit_cuisine"
+										android:layout_width="match_parent"
+										android:layout_height="wrap_content"
+										android:hint="@string/cuisine"
+										android:imeOptions="actionNext"
+										android:inputType="text"
+										android:text="@={recipe.cuisine}" />
+
+								</com.google.android.material.textfield.TextInputLayout>
+
+							</LinearLayout>
+
+							<com.google.android.material.textfield.TextInputLayout
+								style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox.ExposedDropdownMenu"
+								android:layout_width="match_parent"
+								android:layout_height="wrap_content"
+								app:endIconMode="none"
+								app:hintAnimationEnabled="false">
+
+								<com.google.android.material.textfield.MaterialAutoCompleteTextView
+									android:id="@+id/edit_source"
+									android:layout_width="match_parent"
+									android:layout_height="wrap_content"
+									android:hint="@string/source"
+									android:imeOptions="actionNext"
+									android:inputType="text"
+									android:text="@={recipe.source}" />
+
+							</com.google.android.material.textfield.TextInputLayout>
+
+							<com.google.android.material.textfield.TextInputLayout
+								style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"
+								android:layout_width="match_parent"
+								android:layout_height="wrap_content"
+								app:hintAnimationEnabled="false">
+
+								<com.google.android.material.textfield.TextInputEditText
+									android:id="@+id/edit_link"
+									android:layout_width="match_parent"
+									android:layout_height="wrap_content"
+									android:hint="@string/webpage"
+									android:imeOptions="actionNext"
+									android:inputType="text"
+									android:text="@={recipe.link}" />
+
+							</com.google.android.material.textfield.TextInputLayout>
+
+							<LinearLayout
+								android:layout_width="match_parent"
+								android:layout_height="wrap_content"
+								android:layout_marginTop="16dp"
+								android:orientation="horizontal">
+
+								<TextView
+									android:layout_width="0dp"
+									android:layout_height="wrap_content"
+									android:layout_weight="1"
+									android:text="@string/preptime" />
+
+								<TextView
+									android:layout_width="0dp"
+									android:layout_height="wrap_content"
+									android:layout_weight="1"
+									android:text="@string/cooktime" />
+
+							</LinearLayout>
+
+							<LinearLayout
+								android:layout_width="match_parent"
+								android:layout_height="wrap_content"
+								android:baselineAligned="false"
+								android:divider="@drawable/divider_horizontal"
+								android:orientation="horizontal"
+								android:showDividers="middle">
+
+								<com.google.android.material.textfield.TextInputLayout
+									style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"
+									android:layout_width="0dp"
+									android:layout_height="wrap_content"
+									android:layout_weight="0.2"
+									app:expandedHintEnabled="false"
+									app:suffixText="h">
+
+									<com.google.android.material.textfield.TextInputEditText
+										android:id="@+id/edit_preptime_h"
+										android:layout_width="match_parent"
+										android:layout_height="wrap_content"
+										android:imeOptions="actionNext"
+										android:inputType="number"
+										android:text="@={Converter.timeToHour(recipe.preptime, recipe.preptime)}" />
+
+								</com.google.android.material.textfield.TextInputLayout>
+
+								<com.google.android.material.textfield.TextInputLayout
+									style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"
+									android:layout_width="0dp"
+									android:layout_height="wrap_content"
+									android:layout_weight="0.3"
+									app:expandedHintEnabled="false"
+									app:suffixText="min">
+
+									<com.google.android.material.textfield.TextInputEditText
+										android:id="@+id/edit_preptime_min"
+										android:layout_width="match_parent"
+										android:layout_height="wrap_content"
+										android:imeOptions="actionNext"
+										android:inputType="number"
+										android:text="@={Converter.timeToMin(recipe.preptime, recipe.preptime)}" />
+
+								</com.google.android.material.textfield.TextInputLayout>
+
+								<com.google.android.material.textfield.TextInputLayout
+									style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"
+									android:layout_width="0dp"
+									android:layout_height="wrap_content"
+									android:layout_weight="0.2"
+									app:expandedHintEnabled="false"
+									app:suffixText="h">
+
+									<com.google.android.material.textfield.TextInputEditText
+										android:id="@+id/edit_cooktime_h"
+										android:layout_width="match_parent"
+										android:layout_height="wrap_content"
+										android:imeOptions="actionNext"
+										android:inputType="number"
+										android:text="@={Converter.timeToHour(recipe.cooktime, recipe.cooktime)}" />
+
+								</com.google.android.material.textfield.TextInputLayout>
+
+								<com.google.android.material.textfield.TextInputLayout
+									style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"
+									android:layout_width="0dp"
+									android:layout_height="wrap_content"
+									android:layout_weight="0.3"
+									app:expandedHintEnabled="false"
+									app:suffixText="min">
+
+									<com.google.android.material.textfield.TextInputEditText
+										android:id="@+id/edit_cooktime_min"
+										android:layout_width="match_parent"
+										android:layout_height="wrap_content"
+										android:imeOptions="actionNext"
+										android:inputType="number"
+										android:text="@={Converter.timeToMin(recipe.cooktime, recipe.cooktime)}" />
+
+								</com.google.android.material.textfield.TextInputLayout>
+
+							</LinearLayout>
+
+						</LinearLayout>
+
+					</com.google.android.flexbox.FlexboxLayout>
+
+					<com.google.android.flexbox.FlexboxLayout
+						android:layout_width="match_parent"
+						android:layout_height="wrap_content"
+						android:paddingStart="16dp"
+						app:flexWrap="wrap"
+						tools:ignore="RtlSymmetry">
+
+						<LinearLayout
+							android:layout_width="300dp"
+							android:layout_height="wrap_content"
+							android:layout_marginEnd="16dp"
+							android:clipChildren="false"
+							android:divider="@drawable/divider_vertical"
+							android:orientation="vertical"
+							android:showDividers="middle"
+							app:layout_flexGrow="1">
+
+							<TextView
+								android:layout_width="match_parent"
+								android:layout_height="wrap_content"
+								android:text="@string/ingredients" />
+
+							<LinearLayout
+								android:layout_width="match_parent"
+								android:layout_height="wrap_content"
+								android:baselineAligned="false"
+								android:divider="@drawable/divider_horizontal"
+								android:orientation="horizontal"
+								android:showDividers="middle">
+
+								<com.google.android.material.textfield.TextInputLayout
+									style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"
+									android:layout_width="0dp"
+									android:layout_height="wrap_content"
+									android:layout_weight="0.3">
+
+									<com.google.android.material.textfield.TextInputEditText
+										android:id="@+id/edit_yield_value"
+										android:layout_width="match_parent"
+										android:layout_height="wrap_content"
+										android:hint="@string/yield"
+										android:imeOptions="actionNext"
+										android:inputType="numberDecimal"
+										android:text="@={Converter.doubleToString(recipe.yieldValue, recipe.yieldValue)}" />
+
+								</com.google.android.material.textfield.TextInputLayout>
+
+
+								<com.google.android.material.textfield.TextInputLayout
+									style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox.ExposedDropdownMenu"
+									android:layout_width="0dp"
+									android:layout_height="wrap_content"
+									android:layout_weight="0.7"
+									app:endIconMode="none">
+
+									<com.google.android.material.textfield.MaterialAutoCompleteTextView
+										android:id="@+id/edit_yield_unit"
+										android:layout_width="match_parent"
+										android:layout_height="wrap_content"
+										android:imeOptions="actionNext"
+										android:inputType="text"
+										android:text="@={recipe.yieldUnit}" />
+
+								</com.google.android.material.textfield.TextInputLayout>
+
+							</LinearLayout>
+
+							<androidx.recyclerview.widget.RecyclerView
+								android:id="@+id/edit_ingredients"
+								android:layout_width="match_parent"
+								android:layout_height="wrap_content"
+								android:layout_marginHorizontal="-8dp"
+								app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager" />
+
+							<androidx.constraintlayout.widget.ConstraintLayout
+								android:layout_width="match_parent"
+								android:layout_height="wrap_content"
+								android:orientation="vertical">
+
+								<com.google.android.material.button.MaterialButton
+									android:id="@+id/edit_ingredients_new_ingredient"
+									android:layout_width="wrap_content"
+									android:layout_height="wrap_content"
+									android:text="@string/ingredient"
+									app:icon="@drawable/ic_add_circle"
+									tools:ignore="MissingConstraints" />
+
+								<com.google.android.material.button.MaterialButton
+									android:id="@+id/edit_ingredients_new_reference"
+									android:layout_width="wrap_content"
+									android:layout_height="wrap_content"
+									android:text="@string/recipe"
+									app:icon="@drawable/ic_link_new"
+									tools:ignore="MissingConstraints" />
+
+								<com.google.android.material.button.MaterialButton
+									android:id="@+id/edit_ingredients_new_group"
+									android:layout_width="wrap_content"
+									android:layout_height="wrap_content"
+									android:text="@string/group"
+									app:icon="@drawable/ic_group"
+									tools:ignore="MissingConstraints" />
+
+								<androidx.constraintlayout.helper.widget.Flow
+									android:layout_width="match_parent"
+									android:layout_height="wrap_content"
+									app:constraint_referenced_ids="edit_ingredients_new_ingredient, edit_ingredients_new_reference, edit_ingredients_new_group"
+									app:flow_horizontalBias="0.5"
+									app:flow_horizontalGap="8dp"
+									app:flow_horizontalStyle="packed"
+									app:flow_wrapMode="chain"
+									app:layout_constraintTop_toTopOf="parent" />
+
+							</androidx.constraintlayout.widget.ConstraintLayout>
+
+						</LinearLayout>
+
+						<com.google.android.material.textfield.TextInputLayout
+							style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"
+							android:layout_width="300dp"
+							android:layout_height="wrap_content"
+							android:layout_marginEnd="16dp"
+							app:layout_flexGrow="1">
+
+							<com.google.android.material.textfield.TextInputEditText
+								android:id="@+id/edit_instructions"
+								android:layout_width="match_parent"
+								android:layout_height="wrap_content"
+								android:gravity="top"
+								android:hint="@string/instructions"
+								android:inputType="textMultiLine"
+								android:lineSpacingExtra="8sp"
+								android:minLines="5"
+								android:text="@={Converter.htmlToString(recipe.instructions)}" />
+
+						</com.google.android.material.textfield.TextInputLayout>
+
+					</com.google.android.flexbox.FlexboxLayout>
 
 					<com.google.android.material.textfield.TextInputLayout
-						android:layout_width="300dp"
+						style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"
+						android:layout_width="match_parent"
 						android:layout_height="wrap_content"
-						app:layout_flexGrow="1"
-						android:layout_marginEnd="16dp"
-						style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox">
+						android:layout_marginHorizontal="16dp">
 
 						<com.google.android.material.textfield.TextInputEditText
-							android:id="@+id/edit_instructions"
+							android:id="@+id/edit_notes"
 							android:layout_width="match_parent"
 							android:layout_height="wrap_content"
-							android:minLines="5"
-							android:lineSpacingExtra="8sp"
-							android:inputType="textMultiLine"
-							android:hint="@string/instructions"
 							android:gravity="top"
-							android:text="@={Converter.htmlToString(recipe.instructions)}"/>
+							android:hint="@string/notes"
+							android:inputType="textMultiLine"
+							android:lineSpacingExtra="8sp"
+							android:minLines="5"
+							android:text="@={Converter.htmlToString(recipe.notes)}" />
 
 					</com.google.android.material.textfield.TextInputLayout>
 
-				</com.google.android.flexbox.FlexboxLayout>
+				</LinearLayout>
 
-				<com.google.android.material.textfield.TextInputLayout
-					android:layout_width="match_parent"
-					android:layout_height="wrap_content"
-					android:layout_marginHorizontal="16dp"
-					style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox">
+			</com.google.android.material.card.MaterialCardView>
 
-					<com.google.android.material.textfield.TextInputEditText
-						android:id="@+id/edit_notes"
-						android:layout_width="match_parent"
-						android:layout_height="wrap_content"
-						android:minLines="5"
-						android:lineSpacingExtra="8sp"
-						android:inputType="textMultiLine"
-						android:hint="@string/notes"
-						android:gravity="top"
-						android:text="@={Converter.htmlToString(recipe.notes)}"/>
-
-				</com.google.android.material.textfield.TextInputLayout>
-
-			</LinearLayout>
-
-		</com.google.android.material.card.MaterialCardView>
+		</FrameLayout>
 
 	</androidx.core.widget.NestedScrollView>
 

--- a/app/src/main/res/layout/navigation_view.xml
+++ b/app/src/main/res/layout/navigation_view.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
-<com.google.android.material.navigation.NavigationView xmlns:app="http://schemas.android.com/apk/res-auto"
-	xmlns:android="http://schemas.android.com/apk/res/android"
+<com.google.android.material.navigation.NavigationView xmlns:android="http://schemas.android.com/apk/res/android"
+	xmlns:app="http://schemas.android.com/apk/res-auto"
 	android:layout_width="wrap_content"
-	android:layout_height="match_parent"
+	android:layout_height="wrap_content"
 	android:layout_gravity="start">
 
 	<LinearLayout

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -75,10 +75,10 @@
 
 	<!-- For light and dark theme -->
 	<style name="Theme.Tournant.KitchenBackground" parent="Theme.Tournant">
-		<item name="android:windowBackground">@drawable/background_repeat</item>
+<!--		<item name="android:windowBackground">@drawable/background_repeat</item>-->
 	</style>
 	<style name="Theme.Tournant.NoActionBar.KitchenBackground" parent="Theme.Tournant.NoActionBar">
-		<item name="android:windowBackground">@drawable/background_repeat</item>
+<!--		<item name="android:windowBackground">@drawable/background_repeat</item>-->
 	</style>
 
 	<!-- For light and dark theme -->


### PR DESCRIPTION
This patch fixes the layout on API level 35+ by supporting edge-to-edge displays. The style is exactly the same with one minor difference: the repeating background now scrolls with the content rather than being fixed.

This patch does not fix the Settings and About pages, as they use `PreferenceScreen`s, which have been deprecated since Android 10. I assume the only way to fix the layout would be to migrate to a different view. 

I tested this patch on API levels 21, 34, and 35. Closes #28.